### PR TITLE
Better logging for random disturbances

### DIFF
--- a/sim/src/disturbance_experiment.sh
+++ b/sim/src/disturbance_experiment.sh
@@ -15,16 +15,35 @@
 #
 ##
 
+
 num_trials=10
 num_falls=0
+
+# Set up a file to save the results
+save_file="data/data_random_disturbance.csv"
+echo "fx, fy, fz, fell" > $save_file
 
 # Run the experiment
 for i in $(seq 1 $num_trials); do
     echo "***Running trial $i/$num_trials ***"
-    python3 mpc.py > /dev/null
-    if [ $? -ne 0 ]; then
+
+    # Run mpc.py and grab the disturbance values by matching the pattern
+    # Disturbance vector:  [-114.04944531  122.2075357  -231.45198683].
+    output=$(python3 mpc.py)
+    fell=$?
+
+    dist=$(echo $output | grep -oP '\[\K[^\]]+')
+    d1=$(echo $dist | cut -d' ' -f1)
+    d2=$(echo $dist | cut -d' ' -f2)
+    d3=$(echo $dist | cut -d' ' -f3)
+
+    if [ $fell -ne 0 ]; then
         num_falls=$((num_falls+1))
     fi
+
+    # Update the file
+    echo "$d1, $d2, $d3, $fell" >> $save_file
+
 done
 
 echo "Over $num_trials trials, the robot fell $num_falls times"

--- a/sim/src/mpc.py
+++ b/sim/src/mpc.py
@@ -802,14 +802,16 @@ if __name__=="__main__":
     
     # distubance generator
     disturbance_tau = np.zeros(plant.num_velocities())
-    disturbance_tau[3:6] = np.random.multivariate_normal(
+    d = np.random.multivariate_normal(
         config['disturbance']['mu'], 
         np.diag(config['disturbance']['sigma'])**2)
+    disturbance_tau[3:6] = d
     time_applied = config['disturbance']['time_applied']
     duration = config['disturbance']['duration']
     dist_gen = builder.AddSystem(DisturbanceGenerator(plant, 
                                                       meshcat, 
                                                       disturbance_tau, time_applied, duration))
+    print("Disturbance vector: ", d)
 
     # Wire the systems together
     if config['controller']=='MPC':


### PR DESCRIPTION
Records the disturbance magnitudes and failures (or not) in a csv file, as requested in #5.

Does this in a somewhat hacky way, by parsing the text output of `mpc.py`. But it should be enough to make some neat scatter plots of the disturbance magnitudes that each approach is able to handle. 