### PR TITLE
Add video helper utils

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/__pycache__/
 *.csv
 *.avi
+*.html

--- a/sim/config/config.yaml
+++ b/sim/config/config.yaml
@@ -295,3 +295,10 @@ camera:
 
     # Where the meshcat camera is looking
     target: [1.0, 0.0, 0.5]
+
+save_html:
+    # Save the meshcat recording to an html file. This can be used to produce a
+    # video later, or even shared directly with someone to play in their 
+    # browser (even if they don't have Drake or meshcat installed).
+    enabled: True
+    filename: 'recording.html'

--- a/sim/config/config.yaml
+++ b/sim/config/config.yaml
@@ -283,3 +283,15 @@ overhang:
     # Obstacle parameters
     dimensions: [0.5, 2.0, 0.3]  # length, width, height
     position: [1.5, 0.0, 1.3]  # x, y, z
+
+##################################################################################################
+# VISUALIZATION
+##################################################################################################
+
+camera:
+
+    # Position of the Meshcat camera in the world frame
+    position: [2.0,-2.0, 1.0]
+
+    # Where the meshcat camera is looking
+    target: [1.0, 0.0, 0.5]

--- a/sim/src/mpc.py
+++ b/sim/src/mpc.py
@@ -886,6 +886,12 @@ if __name__=="__main__":
     vis_config.publish_contacts = False
     ApplyVisualizationConfig(config=vis_config, builder=builder, meshcat=meshcat)
 
+    # Set the meshcat position and target
+    meshcat.SetCameraPose(
+        config['camera']['position'],
+        config['camera']['target']
+    )
+
     # Build the system diagram
     diagram = builder.Build()
     diagram_context = diagram.CreateDefaultContext()

--- a/sim/src/mpc.py
+++ b/sim/src/mpc.py
@@ -11,7 +11,6 @@ import time
 import numpy as np
 import csv
 import yaml
-import pickle
 
 # import the pydrake modules
 from pydrake.all import (

--- a/sim/src/mpc.py
+++ b/sim/src/mpc.py
@@ -11,6 +11,7 @@ import time
 import numpy as np
 import csv
 import yaml
+import pickle
 
 # import the pydrake modules
 from pydrake.all import (
@@ -924,6 +925,13 @@ if __name__=="__main__":
            f"wall time: {wall_time:.4f}")
     meshcat.StopRecording()
     meshcat.PublishRecording()
+
+    # Save the meshcat recording to an HTML file so anyone can play it back
+    # in their browser, even without meshcat running
+    if config['save_html']['enabled']:
+        html = meshcat.StaticHtml()
+        with open("data/" + config['save_html']['filename'], "w") as f:
+            f.write(html)
 
     if config['logging']==True:
         # unpack recorded data from the logger


### PR DESCRIPTION
Adds some yaml config options for:
- Fixing the camera viewpoint in meshcat
- Saving the recorded simulation to an html file (which can be played back in a web browser without Drake/meshcat)